### PR TITLE
Add miguelandres config for the ploopyco/trackball_thumb

### DIFF
--- a/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
@@ -1,6 +1,7 @@
 /* Copyright 2021 Colin Lam (Ploopy Corporation)
  * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
  * Copyright 2019 Sunjun Kim
+ * Copyright 2024 Miguel Barreto
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
@@ -1,7 +1,7 @@
-/* Copyright 2021 Colin Lam (Ploopy Corporation)
+/* Copyright 2024 Miguel Barreto
+ * Copyright 2021 Colin Lam (Ploopy Corporation)
  * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
  * Copyright 2019 Sunjun Kim
- * Copyright 2024 Miguel Barreto
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
+++ b/keyboards/ploopyco/trackball_thumb/keymaps/miguelandres/keymap.c
@@ -1,0 +1,23 @@
+/* Copyright 2021 Colin Lam (Ploopy Corporation)
+ * Copyright 2020 Christopher Courtney, aka Drashna Jael're  (@drashna) <drashna@live.com>
+ * Copyright 2019 Sunjun Kim
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT(KC_BTN5, KC_BTN1, KC_BTN3, KC_BTN2, MO(1), KC_BTN4),
+    [1] = LAYOUT(KC_MEDIA_NEXT_TRACK,KC_NO,KC_MEDIA_PLAY_PAUSE, KC_NO, KC_NO, KC_MEDIA_PREV_TRACK)
+};


### PR DESCRIPTION
This configuration emulates the default configuration for Logitech's MX Ergos, where the left buttons act as forward (button 5) and back (button 4).

These buttons are the ones closest to the ball, the smaller one being back.

This is different from the default configuration in which the large button on the left is back (now forward) and the rightmost button is forward.

That rightmost button now enables a media control layer, where the back and forward buttons behave the same ant then the middle button is play/pause.